### PR TITLE
Implement barber working hours management

### DIFF
--- a/src/app/(barber)/working-hours/_components/UnavailableDatesForm.tsx
+++ b/src/app/(barber)/working-hours/_components/UnavailableDatesForm.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { useState, useEffect, useActionState } from 'react';
+import { format } from 'date-fns';
+import { toast } from 'sonner';
+import { Calendar } from '@/components/ui/calendar';
+import { Button } from '@/components/ui/button';
+import { updateUnavailableDates } from '../actions';
+import { useFormStatus } from 'react-dom';
+
+interface UnavailableDatesFormProps {
+  initialDates: string[];
+  barberId: string;
+}
+
+const initialState = { message: '' };
+
+function SubmitButton() {
+  const { pending } = useFormStatus();
+  return (
+    <Button type="submit" aria-disabled={pending}>
+      {pending ? 'Kaydediliyor...' : 'Özel Günleri Güncelle'}
+    </Button>
+  );
+}
+
+export function UnavailableDatesForm({ initialDates, barberId }: UnavailableDatesFormProps) {
+  const [selectedDates, setSelectedDates] = useState<Date[]>(initialDates.map(d => new Date(d)));
+  const [state, formAction] = useActionState(updateUnavailableDates, initialState);
+
+  useEffect(() => {
+    if (state?.message) {
+      if (state.message.includes('hata')) {
+        toast.error(state.message);
+      } else {
+        toast.success(state.message);
+      }
+    }
+  }, [state]);
+
+  return (
+    <form action={formAction} className="space-y-4">
+      <input type="hidden" name="barberId" value={barberId} />
+      <Calendar
+        mode="multiple"
+        selected={selectedDates}
+        onSelect={(dates) => setSelectedDates(dates ?? [])}
+        className="rounded-md border"
+      />
+      {selectedDates.map(date => (
+        <input
+          key={date.toISOString()}
+          type="hidden"
+          name="unavailable_dates"
+          value={format(date, 'yyyy-MM-dd')}
+          readOnly
+        />
+      ))}
+      <SubmitButton />
+    </form>
+  );
+}

--- a/src/app/(barber)/working-hours/_components/WorkingHoursForm.tsx
+++ b/src/app/(barber)/working-hours/_components/WorkingHoursForm.tsx
@@ -87,8 +87,8 @@ export function WorkingHoursForm({ initialWorkingHours, barberId }: { initialWor
       {daysOfWeek.map(day => {
         const currentHours = workingHours.find(wh => wh.day_of_week === day.key);
         const isClosed = currentHours?.is_closed || false;
-        const startTime = currentHours?.start_time || '09:00';
-        const endTime = currentHours?.end_time || '18:00';
+        const startTime = currentHours?.start_time ?? '09:00';
+        const endTime = currentHours?.end_time ?? '18:00';
 
         return (
           <div key={day.key} className="flex items-center gap-4 p-4 border rounded-lg bg-gray-50 dark:bg-gray-800 border-gray-200 dark:border-gray-700">

--- a/src/app/(barber)/working-hours/actions.ts
+++ b/src/app/(barber)/working-hours/actions.ts
@@ -7,8 +7,8 @@ import { redirect } from 'next/navigation';
 
 interface WorkingHourData {
   day_of_week: string;
-  start_time: string;
-  end_time: string;
+  start_time: string | null;
+  end_time: string | null;
   is_closed: boolean;
 }
 
@@ -29,14 +29,14 @@ export async function updateWorkingHours(prevState: { message: string }, formDat
   const updates: WorkingHourData[] = [];
 
   for (const day of daysOfWeek) {
-    const startTime = formData.get(`${day}_start_time`) as string;
-    const endTime = formData.get(`${day}_end_time`) as string;
-    const isClosed = formData.get(`${day}_is_closed`) === 'on'; // Checkbox değeri 'on' veya null
+    const startTime = formData.get(`${day}_start_time`) as string | null;
+    const endTime = formData.get(`${day}_end_time`) as string | null;
+    const isClosed = formData.get(`${day}_is_closed`) === 'on';
 
     updates.push({
       day_of_week: day,
-      start_time: isClosed ? '' : startTime,
-      end_time: isClosed ? '' : endTime,
+      start_time: isClosed ? null : startTime,
+      end_time: isClosed ? null : endTime,
       is_closed: isClosed,
     });
   }
@@ -67,5 +67,47 @@ export async function updateWorkingHours(prevState: { message: string }, formDat
   // revalidatePath(`/berber/${barberSlug}`); 
 
   return { message: 'Çalışma saatleri başarıyla güncellendi!' };
+}
+
+interface UnavailableDateData {
+  unavailable_date: string;
+}
+
+export async function updateUnavailableDates(prevState: { message: string }, formData: FormData) {
+  const supabase = await createClient();
+
+  const { data: { user } } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect('/login');
+  }
+
+  const barberId = formData.get('barberId') as string;
+  const dates = formData.getAll('unavailable_dates') as string[];
+
+  const { error: deleteError } = await supabase
+    .from('unavailable_dates')
+    .delete()
+    .eq('barber_id', barberId);
+
+  if (deleteError) {
+    console.error('Error deleting unavailable dates:', deleteError);
+    return { message: 'Özel günler güncellenirken bir hata oluştu.' };
+  }
+
+  if (dates.length > 0) {
+    const insertData: UnavailableDateData[] = dates.map(date => ({ unavailable_date: date }));
+    const { error: insertError } = await supabase
+      .from('unavailable_dates')
+      .insert(insertData.map(d => ({ ...d, barber_id: barberId })));
+
+    if (insertError) {
+      console.error('Error inserting unavailable dates:', insertError);
+      return { message: 'Özel günler güncellenirken bir hata oluştu.' };
+    }
+  }
+
+  revalidatePath('/barber/working-hours');
+  return { message: 'Özel günler başarıyla güncellendi!' };
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -23,8 +23,13 @@ export interface Service {
 
 export interface WorkingHour {
   day_of_week: string;
-  start_time: string;
-  end_time: string;
+  start_time: string | null;
+  end_time: string | null;
+  is_closed?: boolean;
+}
+
+export interface UnavailableDate {
+  unavailable_date: string;
 }
 
 export interface Review {

--- a/supabase_schema.sql
+++ b/supabase_schema.sql
@@ -52,8 +52,9 @@ CREATE TABLE working_hours (
   id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
   barber_id UUID REFERENCES barbers(id) ON DELETE CASCADE,
   day_of_week day_of_week NOT NULL,
-  start_time TIME NOT NULL,
-  end_time TIME NOT NULL,
+  start_time TIME,
+  end_time TIME,
+  is_closed BOOLEAN DEFAULT FALSE,
   created_at TIMESTAMP WITH TIME ZONE DEFAULT now(),
   updated_at TIMESTAMP WITH TIME ZONE DEFAULT now(),
   UNIQUE (barber_id, day_of_week)


### PR DESCRIPTION
## Summary
- allow storing closed status for working hours in DB
- support selecting special closed dates
- fetch and update working hours and unavailable dates
- expose new forms for working hours and special days
- update shared types

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687a56f9cabc83218f604b861ccfd417