### PR TITLE
Implement gallery management for barbers

### DIFF
--- a/src/app/(barber)/gallery/_components/GalleryManager.tsx
+++ b/src/app/(barber)/gallery/_components/GalleryManager.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import { useState, useEffect, useActionState } from 'react';
+import { useFormStatus } from 'react-dom';
+import { uploadGalleryImages, deleteGalleryImage } from '../../actions';
+import { toast } from 'sonner';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import NextImage from 'next/image';
+
+interface GalleryImage {
+  id: string;
+  image_path: string;
+}
+
+const initialState = { message: '' };
+
+function SubmitButton() {
+  const { pending } = useFormStatus();
+  return (
+    <Button type="submit" aria-disabled={pending}>
+      {pending ? 'Yükleniyor...' : 'Fotoğrafları Yükle'}
+    </Button>
+  );
+}
+
+export default function GalleryManager({ images, barberId }: { images: GalleryImage[]; barberId: string }) {
+  const [gallery, setGallery] = useState<GalleryImage[]>(images);
+  const [state, formAction] = useActionState(uploadGalleryImages, initialState);
+
+  useEffect(() => {
+    if (state?.message) {
+      if (state.message.includes('hata')) {
+        toast.error(state.message);
+      } else {
+        toast.success(state.message);
+      }
+    }
+  }, [state]);
+
+  const handleDelete = async (image: GalleryImage) => {
+    const result = await deleteGalleryImage(barberId, image.id, image.image_path);
+    if (result.message.includes('başarı')) {
+      setGallery(prev => prev.filter(img => img.id !== image.id));
+      toast.success(result.message);
+    } else {
+      toast.error(result.message);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <form action={formAction} className="space-y-4">
+        <input type="hidden" name="barberId" value={barberId} />
+        <Input type="file" name="images" multiple className="dark:bg-gray-700 dark:border-gray-600" />
+        <SubmitButton />
+      </form>
+
+      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
+        {gallery.map(img => (
+          <div key={img.id} className="relative group border rounded-md overflow-hidden">
+            <NextImage
+              src={`${process.env.NEXT_PUBLIC_SUPABASE_URL}/storage/v1/object/public/gallery/${img.image_path}`}
+              alt="Berber fotoğraf"
+              width={300}
+              height={120}
+              className="object-cover w-full h-32"
+            />
+            <Button
+              type="button"
+              variant="destructive"
+              size="sm"
+              className="absolute top-1 right-1 opacity-80 group-hover:opacity-100"
+              onClick={() => handleDelete(img)}
+            >
+              Sil
+            </Button>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(barber)/gallery/page.tsx
+++ b/src/app/(barber)/gallery/page.tsx
@@ -1,0 +1,40 @@
+import { createClient } from '@/lib/supabase/server';
+import { redirect } from 'next/navigation';
+import GalleryManager from './_components/GalleryManager';
+
+export default async function GalleryPage() {
+  const supabase = await createClient();
+
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) {
+    redirect('/login');
+  }
+
+  const { data: barber, error: barberError } = await supabase
+    .from('barbers')
+    .select('id')
+    .eq('user_id', user.id)
+    .single();
+
+  if (barberError || !barber) {
+    console.error('Error fetching barber ID:', barberError);
+    return <div>Berber bilgileri yüklenirken bir hata oluştu.</div>;
+  }
+
+  const { data: images, error: imgError } = await supabase
+    .from('barber_gallery')
+    .select('*')
+    .eq('barber_id', barber.id);
+
+  if (imgError) {
+    console.error('Error fetching gallery:', imgError);
+    return <div>Galeri yüklenirken bir hata oluştu.</div>;
+  }
+
+  return (
+    <div>
+      <h1 className="text-2xl font-bold mb-4">Galeri Yönetimi</h1>
+      <GalleryManager images={images || []} barberId={barber.id} />
+    </div>
+  );
+}

--- a/src/app/(barber)/layout.tsx
+++ b/src/app/(barber)/layout.tsx
@@ -1,7 +1,7 @@
 import { createClient } from '@/lib/supabase/server';
 import { redirect } from 'next/navigation';
 import DashboardLayout from '@/components/templates/DashboardLayout';
-import { LayoutDashboard, Calendar, Settings, CreditCard, Clock } from 'lucide-react';
+import { LayoutDashboard, Calendar, Settings, CreditCard, Clock, Image as ImageIcon } from 'lucide-react';
 
 export default async function BarberLayout({ children }: { children: React.ReactNode }) {
   const supabase = await createClient();
@@ -27,6 +27,7 @@ export default async function BarberLayout({ children }: { children: React.React
     { href: '/barber/dashboard', label: 'Anasayfa', icon: <LayoutDashboard className="h-4 w-4" /> },
     { href: '/barber/appointments', label: 'Randevular', icon: <Calendar className="h-4 w-4" /> },
     { href: '/barber/working-hours', label: 'Çalışma Saatleri', icon: <Clock className="h-4 w-4" /> },
+    { href: '/barber/gallery', label: 'Galeri', icon: <ImageIcon className="h-4 w-4" /> },
     { href: '/barber/subscription', label: 'Abonelik', icon: <CreditCard className="h-4 w-4" /> },
     { href: '/barber/settings', label: 'Ayarlar', icon: <Settings className="h-4 w-4" /> },
   ];

--- a/supabase_schema.sql
+++ b/supabase_schema.sql
@@ -117,6 +117,14 @@ CREATE TABLE reviews (
   updated_at TIMESTAMP WITH TIME ZONE DEFAULT now()
 );
 
+-- barber_gallery tablosu
+CREATE TABLE barber_gallery (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  barber_id UUID REFERENCES barbers(id) ON DELETE CASCADE,
+  image_path TEXT NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT now()
+);
+
 -- RLS (Row Level Security) Politikaları
 -- tenants tablosu için RLS
 ALTER TABLE tenants ENABLE ROW LEVEL SECURITY;
@@ -164,6 +172,11 @@ ALTER TABLE reviews ENABLE ROW LEVEL SECURITY;
 CREATE POLICY "Allow public read access to reviews" ON reviews FOR SELECT USING (true);
 CREATE POLICY "Customers can insert their own reviews" ON reviews FOR INSERT WITH CHECK (customer_id IN (SELECT id FROM customers WHERE user_id = auth.uid()));
 CREATE POLICY "Customers can update their own reviews" ON reviews FOR UPDATE USING (customer_id IN (SELECT id FROM customers WHERE user_id = auth.uid()));
+
+-- barber_gallery tablosu için RLS
+ALTER TABLE barber_gallery ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Allow public read access to barber gallery" ON barber_gallery FOR SELECT USING (true);
+CREATE POLICY "Barbers can manage their own gallery" ON barber_gallery FOR ALL USING (barber_id IN (SELECT id FROM barbers WHERE user_id = auth.uid()));
 
 -- Örnek kiracı ekleme
 INSERT INTO tenants (slug, name) VALUES ('ahmetkuafor', 'Ahmet Kuaför');


### PR DESCRIPTION
## Summary
- allow barbers to manage gallery images
- add gallery table and RLS policy in Supabase schema
- expose upload and delete actions for gallery images
- provide Gallery page with upload form and image list
- show new 'Galeri' item in barber panel navigation

## Testing
- `pnpm lint`
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_687a5706cc488321bb49c0e757187d75