### PR TITLE
Implement barber review management

### DIFF
--- a/src/app/(barber)/layout.tsx
+++ b/src/app/(barber)/layout.tsx
@@ -1,7 +1,7 @@
 import { createClient } from '@/lib/supabase/server';
 import { redirect } from 'next/navigation';
 import DashboardLayout from '@/components/templates/DashboardLayout';
-import { LayoutDashboard, Calendar, Settings, CreditCard, Clock, Image as ImageIcon } from 'lucide-react';
+import { LayoutDashboard, Calendar, Settings, CreditCard, Clock, Image as ImageIcon, MessageCircle } from 'lucide-react';
 
 export default async function BarberLayout({ children }: { children: React.ReactNode }) {
   const supabase = await createClient();
@@ -28,6 +28,7 @@ export default async function BarberLayout({ children }: { children: React.React
     { href: '/barber/appointments', label: 'Randevular', icon: <Calendar className="h-4 w-4" /> },
     { href: '/barber/working-hours', label: 'Çalışma Saatleri', icon: <Clock className="h-4 w-4" /> },
     { href: '/barber/gallery', label: 'Galeri', icon: <ImageIcon className="h-4 w-4" /> },
+    { href: '/barber/reviews', label: 'Yorumlar', icon: <MessageCircle className="h-4 w-4" /> },
     { href: '/barber/subscription', label: 'Abonelik', icon: <CreditCard className="h-4 w-4" /> },
     { href: '/barber/settings', label: 'Ayarlar', icon: <Settings className="h-4 w-4" /> },
   ];

--- a/src/app/(barber)/reviews/_components/ReviewResponseForm.tsx
+++ b/src/app/(barber)/reviews/_components/ReviewResponseForm.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { useActionState, useEffect } from 'react';
+import { useFormStatus } from 'react-dom';
+import { respondReview } from '../actions';
+import { Button } from '@/components/ui/button';
+import { toast } from 'sonner';
+
+const initialState = { message: '' };
+
+function SubmitButton() {
+  const { pending } = useFormStatus();
+  return (
+    <Button type="submit" size="sm" aria-disabled={pending}>
+      {pending ? 'Gönderiliyor...' : 'Yanıtı Kaydet'}
+    </Button>
+  );
+}
+
+export default function ReviewResponseForm({ reviewId, initialResponse }: { reviewId: string; initialResponse?: string }) {
+  const [state, formAction] = useActionState(respondReview, initialState);
+
+  useEffect(() => {
+    if (state?.message) {
+      if (state.message.includes('hata')) {
+        toast.error(state.message);
+      } else {
+        toast.success(state.message);
+      }
+    }
+  }, [state]);
+
+  return (
+    <form action={formAction} className="space-y-2 mt-2">
+      <input type="hidden" name="reviewId" value={reviewId} />
+      <textarea
+        name="response"
+        defaultValue={initialResponse}
+        rows={2}
+        className="w-full rounded-md border-gray-300 dark:bg-gray-800 dark:border-gray-600"
+      />
+      <SubmitButton />
+    </form>
+  );
+}

--- a/src/app/(barber)/reviews/actions.ts
+++ b/src/app/(barber)/reviews/actions.ts
@@ -1,0 +1,53 @@
+'use server';
+
+import { createClient } from '@/lib/supabase/server';
+import { revalidatePath } from 'next/cache';
+
+export async function respondReview(prevState: { message: string }, formData: FormData) {
+  const supabase = await createClient();
+
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) {
+    return { message: 'Yetkisiz erişim.' };
+  }
+
+  const reviewId = formData.get('reviewId') as string;
+  const response = formData.get('response') as string;
+
+  if (!reviewId || !response) {
+    return { message: 'Yanıt boş olamaz.' };
+  }
+
+  const { data: barber, error: barberError } = await supabase
+    .from('barbers')
+    .select('id, slug')
+    .eq('user_id', user.id)
+    .single();
+
+  if (barberError || !barber) {
+    console.error('Error fetching barber:', barberError);
+    return { message: 'Berber bulunamadı.' };
+  }
+
+  const { error } = await supabase
+    .from('review_responses')
+    .upsert({
+      review_id: reviewId,
+      barber_id: barber.id,
+      response_text: response,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    }, { onConflict: 'review_id' });
+
+  if (error) {
+    console.error('Error saving response:', error);
+    return { message: 'Yanıt kaydedilirken bir hata oluştu.' };
+  }
+
+  revalidatePath('/barber/reviews');
+  if (barber.slug) {
+    revalidatePath(`/barber/${barber.slug}`);
+  }
+
+  return { message: 'Yanıt başarıyla kaydedildi!' };
+}

--- a/src/app/(barber)/reviews/page.tsx
+++ b/src/app/(barber)/reviews/page.tsx
@@ -1,0 +1,74 @@
+import { createClient } from '@/lib/supabase/server';
+import { redirect } from 'next/navigation';
+import { format } from 'date-fns';
+import { Review } from '@/lib/types';
+import ReviewResponseForm from './_components/ReviewResponseForm';
+import { Star } from 'lucide-react';
+
+export default async function BarberReviewsPage() {
+  const supabase = await createClient();
+
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) {
+    redirect('/login');
+  }
+
+  const { data: barber, error: barberError } = await supabase
+    .from('barbers')
+    .select('id')
+    .eq('user_id', user.id)
+    .single();
+
+  if (barberError || !barber) {
+    console.error('Error fetching barber ID:', barberError);
+    return <div>Yorumlar yüklenirken bir hata oluştu.</div>;
+  }
+
+  const { data: reviews, error: reviewsError } = await supabase
+    .from('reviews')
+    .select(`
+      id, rating, comment, created_at,
+      customers ( name ),
+      review_responses ( id, response_text, created_at )
+    `)
+    .eq('barber_id', barber.id)
+    .order('created_at', { ascending: false });
+
+  if (reviewsError) {
+    console.error('Error fetching reviews:', reviewsError);
+    return <div>Yorumlar yüklenirken bir hata oluştu.</div>;
+  }
+
+  return (
+    <div className="container mx-auto p-4">
+      <h1 className="text-2xl font-bold mb-4 text-gray-900 dark:text-gray-100">Yorumlar</h1>
+      {reviews && reviews.length > 0 ? (
+        <div className="space-y-4">
+          {reviews.map((review: Review) => (
+            <div key={review.id} className="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md border border-gray-200 dark:border-gray-700">
+              <div className="flex items-center gap-2">
+                <span className="font-semibold text-gray-900 dark:text-gray-100">{review.customers.name}</span>
+                <span className="text-sm text-gray-500 dark:text-gray-400">{format(new Date(review.created_at), 'dd.MM.yyyy')}</span>
+              </div>
+              <div className="flex items-center mt-1">
+                {[1,2,3,4,5].map((star) => (
+                  <Star key={star} className={`w-4 h-4 ${review.rating >= star ? 'text-yellow-400 fill-yellow-400' : 'text-gray-300 dark:text-gray-600'}`} />
+                ))}
+              </div>
+              <p className="mt-2 text-gray-700 dark:text-gray-300">{review.comment}</p>
+              {review.review_responses && review.review_responses.length > 0 && (
+                <div className="mt-2 p-2 border-l-2 border-gray-300 dark:border-gray-600">
+                  <p className="text-sm text-gray-600 dark:text-gray-400">Yanıtınız:</p>
+                  <p className="text-gray-800 dark:text-gray-200">{review.review_responses[0].response_text}</p>
+                </div>
+              )}
+              <ReviewResponseForm reviewId={String(review.id)} initialResponse={review.review_responses?.[0]?.response_text} />
+            </div>
+          ))}
+        </div>
+      ) : (
+        <p className="text-gray-600 dark:text-gray-400">Henüz yorum bulunmamaktadır.</p>
+      )}
+    </div>
+  );
+}

--- a/src/app/(public)/barber/[slug]/_components/AppointmentBookingForm.tsx
+++ b/src/app/(public)/barber/[slug]/_components/AppointmentBookingForm.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { useState } from 'react';
+import { ServiceSelector } from '@/components/molecules/ServiceSelector';
+import { AppointmentScheduler } from '@/components/organisms/AppointmentScheduler';
+import { createAppointment } from '../actions';
+import { Service } from "@/lib/types";
+
+interface WorkingHour {
+  day_of_week: string;
+  start_time: string;
+  end_time: string;
+}
+
+interface AppointmentBookingFormProps {
+  barberId: number;
+  tenantId: string;
+  barberSlug: string;
+  services: Service[];
+  workingHours: WorkingHour[];
+}
+
+export function AppointmentBookingForm({
+  barberId,
+  tenantId,
+  barberSlug,
+  services,
+  workingHours,
+}: AppointmentBookingFormProps) {
+  const [selectedServiceId, setSelectedServiceId] = useState<string | number>('');
+  const [selectedServiceDuration, setSelectedServiceDuration] = useState<number | null>(null);
+
+  const handleServiceSelect = (serviceId: string | number, duration: number | null) => {
+    setSelectedServiceId(serviceId);
+    setSelectedServiceDuration(duration);
+  };
+
+  const handleCreateAppointment = async (appointmentTime: Date) => {
+    if (!selectedServiceId) {
+      return;
+    }
+
+    const formData = new FormData();
+    formData.append('barberId', barberId.toString());
+    formData.append('tenantId', tenantId);
+    formData.append('serviceId', selectedServiceId.toString());
+    formData.append('appointmentTime', appointmentTime.toISOString());
+    formData.append('barberSlug', barberSlug);
+
+    await createAppointment(formData);
+  };
+
+  return (
+    <div className="space-y-8">
+      <div>
+        <h2 className="text-2xl font-semibold mb-4 text-gray-900 dark:text-gray-100">Hizmet Seçimi</h2>
+        {services && services.length > 0 ? (
+          <ServiceSelector services={services} onServiceSelect={handleServiceSelect} />
+        ) : (
+          <p className="text-gray-600 dark:text-gray-400">Bu berberin henüz tanımlanmış bir hizmeti bulunmamaktadır.</p>
+        )}
+      </div>
+
+      <div>
+        <h2 className="text-2xl font-semibold mb-4 text-gray-900 dark:text-gray-100">Randevu Takvimi</h2>
+        <AppointmentScheduler
+          barberId={barberId}
+          workingHours={workingHours}
+          selectedServiceDuration={selectedServiceDuration}
+          onCreateAppointment={handleCreateAppointment}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/app/(public)/barber/[slug]/actions.ts
+++ b/src/app/(public)/barber/[slug]/actions.ts
@@ -1,0 +1,53 @@
+'use server';
+
+import { createClient } from '@/lib/supabase/server';
+import { redirect } from 'next/navigation';
+import { revalidatePath } from 'next/cache';
+
+export async function createAppointment(formData: FormData) {
+  const supabase = await createClient();
+
+  const { data: { user } } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect('/login');
+  }
+
+  const barberId = formData.get('barberId') as string;
+  const serviceId = formData.get('serviceId') as string;
+  const appointmentTime = formData.get('appointmentTime') as string;
+  const tenantId = formData.get('tenantId') as string;
+
+  // Müşteri ID'sini al
+  const { data: customerData, error: customerError } = await supabase
+    .from('customers')
+    .select('id')
+    .eq('user_id', user.id)
+    .single();
+
+  if (customerError || !customerData) {
+    console.error('Error fetching customer ID:', customerError);
+    redirect('/login?error=customer-not-found');
+  }
+
+  const customerId = customerData.id;
+
+  const { error } = await supabase.from('appointments').insert({
+    barber_id: barberId,
+    customer_id: customerId,
+    service_id: serviceId,
+    appointment_time: appointmentTime,
+    tenant_id: tenantId,
+    status: 'pending',
+  });
+
+  if (error) {
+    console.error('Error creating appointment:', error);
+    redirect(`/barber/${formData.get('barberSlug')}?error=appointment-failed`);
+  }
+
+  revalidatePath(`/barber/${formData.get('barberSlug')}`);
+  revalidatePath('/dashboard');
+
+  redirect(`/barber/${formData.get('barberSlug')}?success=appointment-created`);
+}

--- a/src/app/(public)/barber/[slug]/page.tsx
+++ b/src/app/(public)/barber/[slug]/page.tsx
@@ -1,0 +1,169 @@
+import { createClient } from '@/lib/supabase/server';
+import { notFound } from 'next/navigation';
+import { AppointmentBookingForm } from './_components/AppointmentBookingForm';
+import { Service, WorkingHour, Review, Barber } from '@/lib/types';
+import { Star, CheckCircle, XCircle } from 'lucide-react';
+import { format } from 'date-fns';
+import { PostgrestError } from "@supabase/supabase-js";
+import { Alert, AlertDescription } from '@/components/ui/alert';
+
+interface PageProps {
+  params: Promise<{ slug: string }>;
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
+}
+
+export default async function BarberProfilePage({ params, searchParams }: PageProps) {
+  const supabase = await createClient();
+
+  const { data: barber, error } = await supabase
+    .from('barbers')
+    .select(
+      `
+      id, name, slug, category, bio, address, tenant_id,
+      services ( id, name, description, price, duration_minutes ),
+      working_hours ( day_of_week, start_time, end_time ),
+      reviews ( id, rating, comment, created_at, customers ( name ), review_responses ( response_text, created_at ) )
+      `
+    )
+    .eq('slug', (await params).slug)
+    .single() as { data: Barber | null, error: PostgrestError | null };
+
+  if (error || !barber) {
+    notFound();
+  }
+
+  // URL parametrelerinden mesajları al
+  const { success, error: urlError } = await searchParams;
+
+  const getMessage = () => {
+    if (success === 'appointment-created') {
+      return {
+        type: 'success' as const,
+        message: 'Randevunuz başarıyla oluşturuldu!'
+      };
+    }
+    if (urlError === 'appointment-failed') {
+      return {
+        type: 'error' as const,
+        message: 'Randevu oluşturulurken bir hata oluştu. Lütfen tekrar deneyin.'
+      };
+    }
+    return null;
+  };
+
+  const message = getMessage();
+
+  const reviews = barber.reviews || [];
+  const averageRating = reviews.length > 0
+    ? (reviews.reduce((acc, review) => acc + review.rating, 0) / reviews.length).toFixed(1)
+    : 'N/A';
+
+  return (
+    <div className="container mx-auto p-4">
+      <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100">{barber.name}</h1>
+      <p className="text-lg text-gray-600 dark:text-gray-400">{barber.category}</p>
+      <div className="flex items-center gap-2 mt-2">
+        <Star className="w-5 h-5 text-yellow-400 fill-yellow-400" />
+        <span className="text-xl font-semibold text-gray-900 dark:text-gray-100">{averageRating}</span>
+        <span className="text-gray-600 dark:text-gray-400">({reviews.length} yorum)</span>
+      </div>
+
+      {message && (
+        <Alert className={`mt-4 ${message.type === 'success' ? 'border-green-200 bg-green-50 dark:bg-green-900/20 dark:border-green-800' : 'border-red-200 bg-red-50 dark:bg-red-900/20 dark:border-red-800'}`}>
+          {message.type === 'success' ? (
+            <CheckCircle className="h-4 w-4 text-green-600 dark:text-green-400" />
+          ) : (
+            <XCircle className="h-4 w-4 text-red-600 dark:text-red-400" />
+          )}
+          <AlertDescription className={message.type === 'success' ? 'text-green-800 dark:text-green-200' : 'text-red-800 dark:text-red-200'}>
+            {message.message}
+          </AlertDescription>
+        </Alert>
+      )}
+
+      <div className="mt-4">
+        <h2 className="text-2xl font-semibold text-gray-900 dark:text-gray-100">Hakkında</h2>
+        <p className="mt-2 text-gray-700 dark:text-gray-300">{barber.bio || 'Bu berber henüz bir tanıtım yazısı eklememiş.'}</p>
+      </div>
+
+      <div className="mt-8">
+        <h2 className="text-2xl font-semibold text-gray-900 dark:text-gray-100">Hizmetler</h2>
+        {barber.services && barber.services.length > 0 ? (
+          <ul className="mt-4 space-y-2">
+            {barber.services.map((service: Service) => (
+              <li key={service.id} className="flex justify-between items-center bg-gray-50 dark:bg-gray-800 p-3 rounded-md">
+                <div>
+                  <h3 className="font-medium text-gray-900 dark:text-gray-100">{service.name}</h3>
+                  <p className="text-sm text-gray-600 dark:text-gray-400">{service.description}</p>
+                </div>
+                <span className="font-semibold text-gray-900 dark:text-gray-100">₺{service.price}</span>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="mt-2 text-gray-600 dark:text-gray-400">Bu berberin henüz tanımlanmış bir hizmeti bulunmamaktadır.</p>
+        )}
+      </div>
+
+      <div className="mt-8">
+        <h2 className="text-2xl font-semibold text-gray-900 dark:text-gray-100">Çalışma Saatleri</h2>
+        {barber.working_hours && barber.working_hours.length > 0 ? (
+          <ul className="mt-4 space-y-2">
+            {barber.working_hours.map((wh: WorkingHour) => (
+              <li key={wh.day_of_week} className="flex justify-between items-center bg-gray-50 dark:bg-gray-800 p-3 rounded-md">
+                <span className="capitalize font-medium text-gray-900 dark:text-gray-100">{wh.day_of_week}</span>
+                <span className="text-gray-700 dark:text-gray-300">{wh.start_time} - {wh.end_time}</span>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="mt-2 text-gray-600 dark:text-gray-400">Bu berberin henüz tanımlanmış çalışma saatleri bulunmamaktadır.</p>
+        )}
+      </div>
+
+      <div className="mt-8">
+        <h2 className="text-2xl font-semibold text-gray-900 dark:text-gray-100">Randevu Al</h2>
+        <AppointmentBookingForm
+          barberId={barber.id}
+          tenantId={barber.tenant_id}
+          barberSlug={barber.slug}
+          services={barber.services}
+          workingHours={barber.working_hours}
+        />
+      </div>
+
+      <div className="mt-8">
+        <h2 className="text-2xl font-semibold text-gray-900 dark:text-gray-100">Yorumlar</h2>
+        {reviews && reviews.length > 0 ? (
+          <div className="space-y-4 mt-4">
+            {reviews.map((review: Review) => (
+              <div key={review.id} className="bg-white dark:bg-gray-800 p-4 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700">
+                <div className="flex items-center gap-2">
+                  <span className="font-semibold text-gray-900 dark:text-gray-100">{review.customers.name}</span>
+                  <span className="text-sm text-gray-500 dark:text-gray-400">{format(new Date(review.created_at), 'dd.MM.yyyy')}</span>
+                </div>
+                <div className="flex items-center mt-1">
+                  {[1, 2, 3, 4, 5].map((star) => (
+                    <Star
+                      key={star}
+                      className={`w-4 h-4 ${review.rating >= star ? 'text-yellow-400 fill-yellow-400' : 'text-gray-300 dark:text-gray-600'}`}
+                    />
+                  ))}
+                </div>
+                <p className="mt-2 text-gray-700 dark:text-gray-300">{review.comment}</p>
+                {review.review_responses && review.review_responses.length > 0 && (
+                  <div className="mt-2 p-2 border-l-2 border-gray-300 dark:border-gray-600">
+                    <p className="text-sm text-gray-600 dark:text-gray-400">Berber Yanıtı:</p>
+                    <p className="text-gray-800 dark:text-gray-200">{review.review_responses[0].response_text}</p>
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        ) : (
+          <p className="mt-2 text-gray-600 dark:text-gray-400">Bu berber için henüz yorum bulunmamaktadır.</p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/molecules/BarberCard.tsx
+++ b/src/components/molecules/BarberCard.tsx
@@ -18,7 +18,7 @@ const categoryTranslations: { [key: string]: string } = {
 
 export function BarberCard({ slug, name, description, address, category }: BarberCardProps) {
   return (
-    <Link href={`/berber/${slug}`} className="block hover:scale-105 transition-transform duration-200">
+    <Link href={`/barber/${slug}`} className="block hover:scale-105 transition-transform duration-200">
       <Card className="h-full flex flex-col">
         <CardHeader>
           <CardTitle>{name}</CardTitle>

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -40,6 +40,13 @@ export interface Review {
   customers: {
     name: string;
   };
+  review_responses?: ReviewResponse[];
+}
+
+export interface ReviewResponse {
+  id: number;
+  response_text: string;
+  created_at: string;
 }
 
 export interface Customer {

--- a/supabase_schema.sql
+++ b/supabase_schema.sql
@@ -118,6 +118,16 @@ CREATE TABLE reviews (
   updated_at TIMESTAMP WITH TIME ZONE DEFAULT now()
 );
 
+-- review_responses tablosu
+CREATE TABLE review_responses (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  review_id UUID REFERENCES reviews(id) ON DELETE CASCADE UNIQUE,
+  barber_id UUID REFERENCES barbers(id) ON DELETE CASCADE,
+  response_text TEXT NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT now(),
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT now()
+);
+
 -- barber_gallery tablosu
 CREATE TABLE barber_gallery (
   id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
@@ -173,6 +183,11 @@ ALTER TABLE reviews ENABLE ROW LEVEL SECURITY;
 CREATE POLICY "Allow public read access to reviews" ON reviews FOR SELECT USING (true);
 CREATE POLICY "Customers can insert their own reviews" ON reviews FOR INSERT WITH CHECK (customer_id IN (SELECT id FROM customers WHERE user_id = auth.uid()));
 CREATE POLICY "Customers can update their own reviews" ON reviews FOR UPDATE USING (customer_id IN (SELECT id FROM customers WHERE user_id = auth.uid()));
+
+-- review_responses tablosu için RLS
+ALTER TABLE review_responses ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Allow public read access to review responses" ON review_responses FOR SELECT USING (true);
+CREATE POLICY "Barbers can manage their own review responses" ON review_responses FOR ALL USING (barber_id IN (SELECT id FROM barbers WHERE user_id = auth.uid()));
 
 -- barber_gallery tablosu için RLS
 ALTER TABLE barber_gallery ENABLE ROW LEVEL SECURITY;


### PR DESCRIPTION
## Summary
- add `review_responses` table and policies in Supabase schema
- extend types with `ReviewResponse`
- enable review management section in barber dashboard
- implement review response form and actions
- expose barber profiles under `/barber/[slug]` and show responses
- link barber cards to new profile route

## Testing
- `apt-get update`
- `apt-get install -y nodejs npm` *(installs Node and npm)*
- `npx next --version` *(downloads Next.js)*
- `npx next lint` *(fails: process interrupted due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_687aa5cbd4a48321ae778fc2c93c300d