### PR TITLE
Add advanced search filters

### DIFF
--- a/src/app/(public)/search/_components/SearchForm.tsx
+++ b/src/app/(public)/search/_components/SearchForm.tsx
@@ -13,9 +13,36 @@ export function SearchForm() {
     router.replace(`${pathname}?${params.toString()}`);
   };
 
+  const handleInputChange = (
+    key: 'location' | 'service',
+    value: string
+  ) => {
+    const params = new URLSearchParams(searchParams);
+    if (value) {
+      params.set(key, value);
+    } else {
+      params.delete(key);
+    }
+    router.replace(`${pathname}?${params.toString()}`);
+  };
+
   return (
     <div className="bg-white p-6 rounded-2xl shadow-soft mb-8">
       <div className="flex flex-col md:flex-row items-center gap-4">
+        <input
+          type="text"
+          placeholder="Konum"
+          defaultValue={searchParams.get('location') || ''}
+          onChange={(e) => handleInputChange('location', e.target.value)}
+          className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
+        />
+        <input
+          type="text"
+          placeholder="Hizmet"
+          defaultValue={searchParams.get('service') || ''}
+          onChange={(e) => handleInputChange('service', e.target.value)}
+          className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
+        />
         <select
           onChange={handleCategoryChange}
           defaultValue={searchParams.get('category') || 'all'}

--- a/src/app/(public)/search/page.tsx
+++ b/src/app/(public)/search/page.tsx
@@ -4,12 +4,25 @@ import { SearchForm } from './_components/SearchForm';
 
 export default async function SearchPage({ searchParams }: { searchParams: Promise<{ [key: string]: string | string[] | undefined }> }) {
   const supabase = await createClient();
-  const category = (await searchParams).category as string || 'all';
+  const params = await searchParams;
+  const category = params.category as string || 'all';
+  const location = params.location as string | undefined;
+  const service = params.service as string | undefined;
 
-  let query = supabase.from('barbers').select('*');
+  let query = supabase
+    .from('barbers')
+    .select('id, name, slug, bio, address, category, services(name)');
 
   if (category && category !== 'all') {
     query = query.eq('category', category);
+  }
+
+  if (location) {
+    query = query.ilike('address', `%${location}%`);
+  }
+
+  if (service) {
+    query = query.ilike('services.name', `%${service}%`);
   }
 
   const { data: barbers, error } = await query;


### PR DESCRIPTION
## Summary
- enhance SearchForm with location and service inputs
- extend search page query to filter by location, service and category

## Testing
- `pnpm lint`
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_687aafc8b2488321bdd8a71ce0cea6d4