### PR TITLE
Implement customer favorites

### DIFF
--- a/src/app/(customer)/customer-dashboard/page.tsx
+++ b/src/app/(customer)/customer-dashboard/page.tsx
@@ -116,7 +116,7 @@ export default function DashboardPage() { // async kaldırıldı
               </Link>
             </li>
             <li className="mb-4">
-              <Link href="/customer-dashboard/favorites" className="flex items-center gap-3 text-foreground hover:text-primary font-medium">
+              <Link href="/favorites" className="flex items-center gap-3 text-foreground hover:text-primary font-medium">
                 <Heart size={20} /> Favorites
               </Link>
             </li>
@@ -163,7 +163,7 @@ export default function DashboardPage() { // async kaldırıldı
             <Link href="/search" className="inline-block bg-primary hover:bg-primary-dark text-white font-bold py-2 px-4 rounded-2xl shadow-soft text-center transition duration-300">
               Yeni Randevu Al
             </Link>
-            <Link href="/dashboard/favorites" className="inline-block bg-secondary hover:bg-secondary-dark text-foreground font-bold py-2 px-4 rounded-2xl shadow-soft text-center transition duration-300">
+            <Link href="/favorites" className="inline-block bg-secondary hover:bg-secondary-dark text-foreground font-bold py-2 px-4 rounded-2xl shadow-soft text-center transition duration-300">
               Favori Berberlerim
             </Link>
           </div>

--- a/src/app/(customer)/favorites/actions.ts
+++ b/src/app/(customer)/favorites/actions.ts
@@ -1,0 +1,92 @@
+'use server';
+
+import { createClient } from '@/lib/supabase/server';
+import { revalidatePath } from 'next/cache';
+import { redirect } from 'next/navigation';
+
+export async function addFavorite(formData: FormData) {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) {
+    redirect('/login');
+  }
+
+  const barberId = formData.get('barberId') as string;
+  const barberSlug = formData.get('barberSlug') as string;
+
+  const { data: customerData, error: customerError } = await supabase
+    .from('customers')
+    .select('id')
+    .eq('user_id', user.id)
+    .single();
+
+  if (customerError || !customerData) {
+    console.error('Error fetching customer ID:', customerError);
+    redirect(`/barber/${barberSlug}?error=favorite-failed`);
+  }
+
+  const { error } = await supabase
+    .from('customer_favorites')
+    .insert({ barber_id: barberId, customer_id: customerData.id });
+
+  if (error) {
+    console.error('Error adding favorite:', error);
+    redirect(`/barber/${barberSlug}?error=favorite-failed`);
+  }
+
+  revalidatePath(`/barber/${barberSlug}`);
+  revalidatePath('/favorites');
+
+  redirect(`/barber/${barberSlug}?success=favorite-added`);
+}
+
+export async function removeFavorite(formData: FormData) {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) {
+    redirect('/login');
+  }
+
+  const barberId = formData.get('barberId') as string;
+  const barberSlug = formData.get('barberSlug') as string | null;
+  const redirectTo = formData.get('redirectTo') as string | null;
+
+  const { data: customerData, error: customerError } = await supabase
+    .from('customers')
+    .select('id')
+    .eq('user_id', user.id)
+    .single();
+
+  if (customerError || !customerData) {
+    console.error('Error fetching customer ID:', customerError);
+    if (redirectTo) {
+      redirect(`${redirectTo}?error=favorite-failed`);
+    }
+    redirect(`/barber/${barberSlug}?error=favorite-failed`);
+  }
+
+  const { error } = await supabase
+    .from('customer_favorites')
+    .delete()
+    .eq('barber_id', barberId)
+    .eq('customer_id', customerData.id);
+
+  if (error) {
+    console.error('Error removing favorite:', error);
+    if (redirectTo) {
+      redirect(`${redirectTo}?error=favorite-failed`);
+    }
+    redirect(`/barber/${barberSlug}?error=favorite-failed`);
+  }
+
+  if (barberSlug) {
+    revalidatePath(`/barber/${barberSlug}`);
+  }
+  revalidatePath('/favorites');
+
+  if (redirectTo) {
+    redirect(`${redirectTo}?success=favorite-removed`);
+  }
+
+  redirect(`/barber/${barberSlug}?success=favorite-removed`);
+}

--- a/src/app/(customer)/favorites/page.tsx
+++ b/src/app/(customer)/favorites/page.tsx
@@ -1,0 +1,94 @@
+import { createClient } from '@/lib/supabase/server';
+import { redirect } from 'next/navigation';
+import Link from 'next/link';
+import { Button } from '@/components/ui/button';
+import { removeFavorite } from './actions';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { CheckCircle, XCircle } from 'lucide-react';
+
+interface PageProps {
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
+}
+
+export default async function FavoritesPage({ searchParams }: PageProps) {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect('/login');
+  }
+
+  const { data: customerData, error: customerError } = await supabase
+    .from('customers')
+    .select('id')
+    .eq('user_id', user.id)
+    .single();
+
+  if (customerError || !customerData) {
+    console.error('Error fetching customer ID:', customerError);
+    return <div>Favoriler yüklenirken bir hata oluştu.</div>;
+  }
+
+  const { data: favorites, error: favError } = await supabase
+    .from('customer_favorites')
+    .select('barber_id, barbers ( name, slug )')
+    .eq('customer_id', customerData.id);
+
+  if (favError) {
+    console.error('Error fetching favorites:', favError);
+    return <div>Favoriler yüklenirken bir hata oluştu.</div>;
+  }
+
+  const params = await searchParams;
+  const { success, error } = params;
+
+  const getMessage = () => {
+    if (success === 'favorite-removed') {
+      return { type: 'success' as const, message: 'Favori başarıyla kaldırıldı!' };
+    }
+    if (error === 'favorite-failed') {
+      return { type: 'error' as const, message: 'İşlem sırasında bir hata oluştu.' };
+    }
+    return null;
+  };
+
+  const message = getMessage();
+
+  return (
+    <div className="container mx-auto p-4">
+      <h1 className="text-2xl font-bold mb-4">Favori Berberlerim</h1>
+
+      {message && (
+        <Alert className={`mb-4 ${message.type === 'success' ? 'border-green-200 bg-green-50 dark:bg-green-900/20 dark:border-green-800' : 'border-red-200 bg-red-50 dark:bg-red-900/20 dark:border-red-800'}`}>\
+          {message.type === 'success' ? (
+            <CheckCircle className="h-4 w-4 text-green-600 dark:text-green-400" />
+          ) : (
+            <XCircle className="h-4 w-4 text-red-600 dark:text-red-400" />
+          )}
+          <AlertDescription className={message.type === 'success' ? 'text-green-800 dark:text-green-200' : 'text-red-800 dark:text-red-200'}>
+            {message.message}
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {favorites && favorites.length > 0 ? (
+        <ul className="space-y-4">
+          {favorites.map((fav) => (
+            <li key={fav.barber_id} className="flex items-center justify-between bg-card p-4 rounded-lg shadow-soft">
+              <Link href={`/barber/${fav.barbers.slug}`} className="font-medium hover:underline">
+                {fav.barbers.name}
+              </Link>
+              <form action={removeFavorite}>
+                <input type="hidden" name="barberId" value={fav.barber_id} />
+                <input type="hidden" name="redirectTo" value="/favorites" />
+                <Button variant="destructive" size="sm">Kaldır</Button>
+              </form>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p className="text-gray-600 dark:text-gray-400">Henüz favori berberiniz bulunmamaktadır.</p>
+      )}
+    </div>
+  );
+}

--- a/src/app/(customer)/layout.tsx
+++ b/src/app/(customer)/layout.tsx
@@ -1,7 +1,7 @@
 import { createClient } from '@/lib/supabase/server';
 import { redirect } from 'next/navigation';
 import DashboardLayout from '@/components/templates/DashboardLayout';
-import { LayoutDashboard, User, Calendar } from 'lucide-react';
+import { LayoutDashboard, User, Calendar, Heart } from 'lucide-react';
 
 export default async function ProtectedLayout({ children }: { children: React.ReactNode }) {
   const supabase = await createClient();
@@ -15,6 +15,7 @@ export default async function ProtectedLayout({ children }: { children: React.Re
   const customerNavItems = [
     { href: '/customer-dashboard', label: 'Anasayfa', icon: <LayoutDashboard /> },
     { href: '/profile', label: 'Profilim', icon: <User /> },
+    { href: '/favorites', label: 'Favorilerim', icon: <Heart /> },
     { href: '/my-appointments', label: 'Randevularım', icon: <Calendar /> },
   ];
 

--- a/src/app/(public)/barber/[slug]/_components/FavoriteButton.tsx
+++ b/src/app/(public)/barber/[slug]/_components/FavoriteButton.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { useTransition } from 'react';
+import { addFavorite, removeFavorite } from '@/app/(customer)/favorites/actions';
+import { Button } from '@/components/ui/button';
+import { toast } from 'sonner';
+
+interface FavoriteButtonProps {
+  barberId: string;
+  barberSlug: string;
+  isFavorite: boolean;
+}
+
+export default function FavoriteButton({ barberId, barberSlug, isFavorite }: FavoriteButtonProps) {
+  const [isPending, startTransition] = useTransition();
+
+  const handleAction = () => {
+    const formData = new FormData();
+    formData.append('barberId', barberId);
+    formData.append('barberSlug', barberSlug);
+    if (isFavorite) {
+      formData.append('redirectTo', `/barber/${barberSlug}`);
+      startTransition(async () => {
+        try {
+          await removeFavorite(formData);
+        } catch {
+          toast.error('Favori kaldırılırken hata oluştu');
+        }
+      });
+    } else {
+      startTransition(async () => {
+        try {
+          await addFavorite(formData);
+        } catch {
+          toast.error('Favoriye eklenirken hata oluştu');
+        }
+      });
+    }
+  };
+
+  return (
+    <Button type="button" onClick={handleAction} variant={isFavorite ? 'secondary' : 'default'} disabled={isPending} size="sm">
+      {isFavorite ? 'Favoriden Çıkar' : 'Favorilere Ekle'}
+    </Button>
+  );
+}

--- a/supabase_schema.sql
+++ b/supabase_schema.sql
@@ -136,6 +136,15 @@ CREATE TABLE barber_gallery (
   created_at TIMESTAMP WITH TIME ZONE DEFAULT now()
 );
 
+-- customer_favorites tablosu
+CREATE TABLE customer_favorites (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  customer_id UUID REFERENCES customers(id) ON DELETE CASCADE,
+  barber_id UUID REFERENCES barbers(id) ON DELETE CASCADE,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT now(),
+  UNIQUE (customer_id, barber_id)
+);
+
 -- RLS (Row Level Security) Politikaları
 -- tenants tablosu için RLS
 ALTER TABLE tenants ENABLE ROW LEVEL SECURITY;
@@ -193,6 +202,14 @@ CREATE POLICY "Barbers can manage their own review responses" ON review_response
 ALTER TABLE barber_gallery ENABLE ROW LEVEL SECURITY;
 CREATE POLICY "Allow public read access to barber gallery" ON barber_gallery FOR SELECT USING (true);
 CREATE POLICY "Barbers can manage their own gallery" ON barber_gallery FOR ALL USING (barber_id IN (SELECT id FROM barbers WHERE user_id = auth.uid()));
+
+-- customer_favorites tablosu için RLS
+ALTER TABLE customer_favorites ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Customers manage their own favorites" ON customer_favorites FOR ALL USING (
+  customer_id IN (SELECT id FROM customers WHERE user_id = auth.uid())
+) WITH CHECK (
+  customer_id IN (SELECT id FROM customers WHERE user_id = auth.uid())
+);
 
 -- Örnek kiracı ekleme
 INSERT INTO tenants (slug, name) VALUES ('ahmetkuafor', 'Ahmet Kuaför');


### PR DESCRIPTION
## Summary
- add `customer_favorites` table and RLS policies
- allow adding and removing favorites with server actions
- show favorites page in customer dashboard
- add FavoriteButton on barber profile
- update customer navigation and dashboard links

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687ab4ead6308321a78a54871cd4f099