### PR TITLE
Add appointment conflict validation

### DIFF
--- a/src/app/(public)/barber/[slug]/actions.ts
+++ b/src/app/(public)/barber/[slug]/actions.ts
@@ -18,6 +18,19 @@ export async function createAppointment(formData: FormData) {
   const appointmentTime = formData.get('appointmentTime') as string;
   const tenantId = formData.get('tenantId') as string;
 
+  // Aynı berber ve zaman için çakışan randevu var mı kontrol et
+  const { data: existingAppointment } = await supabase
+    .from('appointments')
+    .select('id')
+    .eq('barber_id', barberId)
+    .eq('appointment_time', appointmentTime)
+    .neq('status', 'cancelled')
+    .maybeSingle();
+
+  if (existingAppointment) {
+    redirect(`/barber/${formData.get('barberSlug')}?error=appointment-conflict`);
+  }
+
   // Müşteri ID'sini al
   const { data: customerData, error: customerError } = await supabase
     .from('customers')

--- a/src/app/(public)/barber/[slug]/page.tsx
+++ b/src/app/(public)/barber/[slug]/page.tsx
@@ -61,6 +61,12 @@ export default async function BarberProfilePage({ params, searchParams }: PagePr
         message: 'Randevu oluşturulurken bir hata oluştu. Lütfen tekrar deneyin.'
       };
     }
+    if (urlError === 'appointment-conflict') {
+      return {
+        type: 'error' as const,
+        message: 'Seçilen saat için zaten bir randevu var. Lütfen başka bir zaman seçin.'
+      };
+    }
     if (urlError === 'favorite-failed') {
       return {
         type: 'error' as const,

--- a/src/app/(public)/shop/[slug]/actions.ts
+++ b/src/app/(public)/shop/[slug]/actions.ts
@@ -18,6 +18,19 @@ export async function createAppointment(formData: FormData) {
   const appointmentTime = formData.get('appointmentTime') as string;
   const tenantId = formData.get('tenantId') as string;
 
+  // Aynı berber ve zaman için çakışan randevu var mı kontrol et
+  const { data: existingAppointment } = await supabase
+    .from('appointments')
+    .select('id')
+    .eq('barber_id', barberId)
+    .eq('appointment_time', appointmentTime)
+    .neq('status', 'cancelled')
+    .maybeSingle();
+
+  if (existingAppointment) {
+    redirect(`/shop/${formData.get('barberSlug')}?error=appointment-conflict`);
+  }
+
   // Müşteri ID'sini al
   const { data: customerData, error: customerError } = await supabase
     .from('customers')

--- a/src/app/(public)/shop/[slug]/page.tsx
+++ b/src/app/(public)/shop/[slug]/page.tsx
@@ -48,6 +48,12 @@ export default async function BarberProfilePage({ params, searchParams }: PagePr
         message: 'Randevu oluşturulurken bir hata oluştu. Lütfen tekrar deneyin.'
       };
     }
+    if (urlError === 'appointment-conflict') {
+      return {
+        type: 'error' as const,
+        message: 'Seçilen saat için zaten bir randevu var. Lütfen başka bir zaman seçin.'
+      };
+    }
     return null;
   };
 


### PR DESCRIPTION
## Summary
- prevent overlapping appointments when booking
- show a clear error message on barber and shop pages when a conflict occurs

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687e05573fac8321b92b8e961db57675