### PR TITLE
Implement Sonner toast notifications

### DIFF
--- a/src/app/(barber)/appointments/page.tsx
+++ b/src/app/(barber)/appointments/page.tsx
@@ -6,8 +6,7 @@ import { tr } from 'date-fns/locale';
 import { updateAppointmentStatus } from './actions';
 import { Button } from '@/components/ui/button';
 import { StatusFilter } from './_components/StatusFilter';
-import { Alert, AlertDescription } from '@/components/ui/alert';
-import { CheckCircle, XCircle } from 'lucide-react';
+import ToastMessage from '@/components/molecules/ToastMessage';
 
 interface PageProps {
   searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
@@ -72,18 +71,7 @@ export default async function BarberAppointmentsPage({ searchParams }: PageProps
   return (
     <div className="container mx-auto p-4">
       <h1 className="text-2xl font-bold mb-4 text-gray-900 dark:text-gray-100">Randevular</h1>
-      {message && (
-        <Alert className={`mb-4 ${message.type === 'success' ? 'border-green-200 bg-green-50 dark:bg-green-900/20 dark:border-green-800' : 'border-red-200 bg-red-50 dark:bg-red-900/20 dark:border-red-800'}`}> 
-          {message.type === 'success' ? (
-            <CheckCircle className="h-4 w-4 text-green-600 dark:text-green-400" />
-          ) : (
-            <XCircle className="h-4 w-4 text-red-600 dark:text-red-400" />
-          )}
-          <AlertDescription className={message.type === 'success' ? 'text-green-800 dark:text-green-200' : 'text-red-800 dark:text-red-200'}>
-            {message.message}
-          </AlertDescription>
-        </Alert>
-      )}
+      {message && <ToastMessage type={message.type} message={message.message} />}
       <StatusFilter currentStatus={filterStatus} />
       {appointments && appointments.length > 0 ? (
         <div className="space-y-4">

--- a/src/app/(barber)/subscription/page.tsx
+++ b/src/app/(barber)/subscription/page.tsx
@@ -2,8 +2,13 @@ import { createClient } from '@/lib/supabase/server';
 import { redirect } from 'next/navigation';
 import { PricingCard } from '@/components/organisms/PricingCard';
 import { subscribeToPlan } from './actions';
+import ToastMessage from '@/components/molecules/ToastMessage';
 
-export default async function SubscriptionPage() {
+interface PageProps {
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
+}
+
+export default async function SubscriptionPage({ searchParams }: PageProps) {
   const supabase = await createClient();
 
   const { data: { user } } = await supabase.auth.getUser();
@@ -33,10 +38,26 @@ export default async function SubscriptionPage() {
     );
   }
 
+  const params = await searchParams;
+  const { success, error: urlError } = params;
+
+  const getMessage = () => {
+    if (success === 'subscribed') {
+      return { type: 'success' as const, message: 'Abonelik başarıyla güncellendi!' };
+    }
+    if (urlError === 'subscription_failed') {
+      return { type: 'error' as const, message: 'Abonelik güncellenirken bir hata oluştu.' };
+    }
+    return null;
+  };
+
+  const message = getMessage();
+
   const isSubscribed = barber?.subscription_status === 'active';
 
   return (
     <div className="container mx-auto p-4">
+      {message && <ToastMessage type={message.type} message={message.message} />}
       <h1 className="text-2xl font-bold mb-4 text-gray-900 dark:text-gray-100">Abonelik Yönetimi</h1>
       <div className="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md mb-8 border border-gray-200 dark:border-gray-700">
         <p className="text-lg text-gray-700 dark:text-gray-300">

--- a/src/app/(customer)/favorites/page.tsx
+++ b/src/app/(customer)/favorites/page.tsx
@@ -3,8 +3,7 @@ import { redirect } from 'next/navigation';
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
 import { removeFavorite } from './actions';
-import { Alert, AlertDescription } from '@/components/ui/alert';
-import { CheckCircle, XCircle } from 'lucide-react';
+import ToastMessage from '@/components/molecules/ToastMessage';
 
 interface PageProps {
   searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
@@ -58,18 +57,7 @@ export default async function FavoritesPage({ searchParams }: PageProps) {
     <div className="container mx-auto p-4">
       <h1 className="text-2xl font-bold mb-4">Favori Berberlerim</h1>
 
-      {message && (
-        <Alert className={`mb-4 ${message.type === 'success' ? 'border-green-200 bg-green-50 dark:bg-green-900/20 dark:border-green-800' : 'border-red-200 bg-red-50 dark:bg-red-900/20 dark:border-red-800'}`}>\
-          {message.type === 'success' ? (
-            <CheckCircle className="h-4 w-4 text-green-600 dark:text-green-400" />
-          ) : (
-            <XCircle className="h-4 w-4 text-red-600 dark:text-red-400" />
-          )}
-          <AlertDescription className={message.type === 'success' ? 'text-green-800 dark:text-green-200' : 'text-red-800 dark:text-red-200'}>
-            {message.message}
-          </AlertDescription>
-        </Alert>
-      )}
+      {message && <ToastMessage type={message.type} message={message.message} />}
 
       {favorites && favorites.length > 0 ? (
         <ul className="space-y-4">

--- a/src/app/(customer)/my-appointments/page.tsx
+++ b/src/app/(customer)/my-appointments/page.tsx
@@ -6,8 +6,7 @@ import { tr } from 'date-fns/locale';
 import { ReviewForm } from '@/components/molecules/ReviewForm';
 import { Button } from '@/components/ui/button';
 import { cancelAppointment } from './actions';
-import { Alert, AlertDescription } from '@/components/ui/alert';
-import { CheckCircle, XCircle } from 'lucide-react';
+import ToastMessage from '@/components/molecules/ToastMessage';
 
 interface PageProps {
   searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
@@ -88,18 +87,7 @@ export default async function MyAppointmentsPage({ searchParams }: PageProps) {
     <div className="container mx-auto p-4">
       <h1 className="text-2xl font-bold mb-4">Randevularım</h1>
       
-      {message && (
-        <Alert className={`mb-4 ${message.type === 'success' ? 'border-green-200 bg-green-50 dark:bg-green-900/20 dark:border-green-800' : 'border-red-200 bg-red-50 dark:bg-red-900/20 dark:border-red-800'}`}>
-          {message.type === 'success' ? (
-            <CheckCircle className="h-4 w-4 text-green-600 dark:text-green-400" />
-          ) : (
-            <XCircle className="h-4 w-4 text-red-600 dark:text-red-400" />
-          )}
-          <AlertDescription className={message.type === 'success' ? 'text-green-800 dark:text-green-200' : 'text-red-800 dark:text-red-200'}>
-            {message.message}
-          </AlertDescription>
-        </Alert>
-      )}
+      {message && <ToastMessage type={message.type} message={message.message} />}
 
       {appointments && appointments.length > 0 ? (
         <div className="space-y-4">

--- a/src/app/(public)/barber/[slug]/page.tsx
+++ b/src/app/(public)/barber/[slug]/page.tsx
@@ -2,11 +2,11 @@ import { createClient } from '@/lib/supabase/server';
 import { notFound } from 'next/navigation';
 import { AppointmentBookingForm } from './_components/AppointmentBookingForm';
 import { Service, WorkingHour, Review, Barber } from '@/lib/types';
-import { Star, CheckCircle, XCircle } from 'lucide-react';
+import { Star } from 'lucide-react';
 import FavoriteButton from './_components/FavoriteButton';
 import { format } from 'date-fns';
 import { PostgrestError } from "@supabase/supabase-js";
-import { Alert, AlertDescription } from '@/components/ui/alert';
+import ToastMessage from '@/components/molecules/ToastMessage';
 
 interface PageProps {
   params: Promise<{ slug: string }>;
@@ -117,18 +117,7 @@ export default async function BarberProfilePage({ params, searchParams }: PagePr
         </div>
       )}
 
-      {message && (
-        <Alert className={`mt-4 ${message.type === 'success' ? 'border-green-200 bg-green-50 dark:bg-green-900/20 dark:border-green-800' : 'border-red-200 bg-red-50 dark:bg-red-900/20 dark:border-red-800'}`}>
-          {message.type === 'success' ? (
-            <CheckCircle className="h-4 w-4 text-green-600 dark:text-green-400" />
-          ) : (
-            <XCircle className="h-4 w-4 text-red-600 dark:text-red-400" />
-          )}
-          <AlertDescription className={message.type === 'success' ? 'text-green-800 dark:text-green-200' : 'text-red-800 dark:text-red-200'}>
-            {message.message}
-          </AlertDescription>
-        </Alert>
-      )}
+      {message && <ToastMessage type={message.type} message={message.message} />}
 
       <div className="mt-4">
         <h2 className="text-2xl font-semibold text-gray-900 dark:text-gray-100">Hakkında</h2>

--- a/src/app/(public)/shop/[slug]/page.tsx
+++ b/src/app/(public)/shop/[slug]/page.tsx
@@ -2,10 +2,10 @@ import { createClient } from '@/lib/supabase/server';
 import { notFound } from 'next/navigation';
 import { AppointmentBookingForm } from './_components/AppointmentBookingForm';
 import { Service, WorkingHour, Review, Barber } from '@/lib/types';
-import { Star, CheckCircle, XCircle } from 'lucide-react';
+import { Star } from 'lucide-react';
 import { format } from 'date-fns';
 import { PostgrestError } from "@supabase/supabase-js";
-import { Alert, AlertDescription } from '@/components/ui/alert';
+import ToastMessage from '@/components/molecules/ToastMessage';
 
 interface PageProps {
   params: Promise<{ slug: string }>;
@@ -74,18 +74,7 @@ export default async function BarberProfilePage({ params, searchParams }: PagePr
         <span className="text-gray-600 dark:text-gray-400">({reviews.length} yorum)</span>
       </div>
 
-      {message && (
-        <Alert className={`mt-4 ${message.type === 'success' ? 'border-green-200 bg-green-50 dark:bg-green-900/20 dark:border-green-800' : 'border-red-200 bg-red-50 dark:bg-red-900/20 dark:border-red-800'}`}>
-          {message.type === 'success' ? (
-            <CheckCircle className="h-4 w-4 text-green-600 dark:text-green-400" />
-          ) : (
-            <XCircle className="h-4 w-4 text-red-600 dark:text-red-400" />
-          )}
-          <AlertDescription className={message.type === 'success' ? 'text-green-800 dark:text-green-200' : 'text-red-800 dark:text-red-200'}>
-            {message.message}
-          </AlertDescription>
-        </Alert>
-      )}
+      {message && <ToastMessage type={message.type} message={message.message} />}
 
       <div className="mt-4">
         <h2 className="text-2xl font-semibold text-gray-900 dark:text-gray-100">Hakkında</h2>

--- a/src/components/molecules/ToastMessage.tsx
+++ b/src/components/molecules/ToastMessage.tsx
@@ -1,0 +1,29 @@
+"use client";
+import { useEffect } from "react";
+import { toast } from "sonner";
+
+interface ToastMessageProps {
+  type: "success" | "error" | "warning" | "info";
+  message: string;
+}
+
+export default function ToastMessage({ type, message }: ToastMessageProps) {
+  useEffect(() => {
+    if (!message) return;
+    switch (type) {
+      case "success":
+        toast.success(message);
+        break;
+      case "error":
+        toast.error(message);
+        break;
+      case "warning":
+        toast.warning(message);
+        break;
+      default:
+        toast(message);
+    }
+  }, [type, message]);
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- create `ToastMessage` client component to trigger Sonner toasts
- use `ToastMessage` on server-rendered pages for feedback

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687e1545c8988321bc31aa7b36184561